### PR TITLE
Fix capitalisation for Atom standard

### DIFF
--- a/menus/remote-edit.cson
+++ b/menus/remote-edit.cson
@@ -3,12 +3,12 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'Remote edit'
+      'label': 'Remote Edit'
       'submenu': [
-        { 'label': 'Show open files', 'command': 'remote-edit:show-open-files' }
-        { 'label': 'Browse hosts', 'command': 'remote-edit:browse' }
-        { 'label': 'Add new host (sftp)', 'command': 'remote-edit:new-host-sftp' }
-        { 'label': 'Add new host (ftp)', 'command': 'remote-edit:new-host-ftp' }
+        { 'label': 'Show Open Files', 'command': 'remote-edit:show-open-files' }
+        { 'label': 'Browse Hosts', 'command': 'remote-edit:browse' }
+        { 'label': 'Add New Host (sftp)', 'command': 'remote-edit:new-host-sftp' }
+        { 'label': 'Add New Host (ftp)', 'command': 'remote-edit:new-host-ftp' }
     ]
     ]
   }


### PR DESCRIPTION
It seems to be an impromptu standard for Atom package menus to be all initials capitalised (Camel Case). I don't know why. Just noticed this and thought I'd fix it up for you.
