### PR TITLE
Avoiding overwriting open folder command

### DIFF
--- a/keymaps/remote-edit.cson
+++ b/keymaps/remote-edit.cson
@@ -12,8 +12,8 @@
   'ctrl-cmd-o': 'remote-edit:show-open-files'
 
 '.platform-win32, .platform-linux':
-  'ctrl-shift-b': 'remote-edit:browse'
-  'ctrl-shift-o': 'remote-edit:show-open-files'
+  'ctrl-alt-b': 'remote-edit:browse'
+  'ctrl-alt-o': 'remote-edit:show-open-files'
 
 '.open-files-view.select-list':
   'shift-d': 'openfilesview:delete'


### PR DESCRIPTION
On Windows, the open folder keyboard shortcut is ctrl-shift-o, which this plugin was overwriting. I've changed this to ctrl-alt-o.

See issue #57 