### PR TITLE
Fixed duplicate filenames' long and cut off title.

### DIFF
--- a/lib/model/remote-edit-editor.coffee
+++ b/lib/model/remote-edit-editor.coffee
@@ -44,11 +44,14 @@ module.exports =
       FtpHost ?= require './ftp-host'
       SftpHost ?= require './sftp-host'
 
+      if i = @localFile.remoteFile.path.indexOf(@host.directory) > -1
+        relativePath = @localFile.remoteFile.path[(i+@host.directory.length)..]
+
       fileName = @getTitle()
       if @host instanceof SftpHost and @host? and @localFile?
-        directory = "sftp://#{@host.username}@#{@host.hostname}:#{@host.port}#{@localFile.remoteFile.path}"
+        directory = if relativePath? then relativePath else "sftp://#{@host.username}@#{@host.hostname}:#{@host.port}#{@localFile.remoteFile.path}"
       else if @host instanceof FtpHost and @host? and @localFile?
-        directory = "ftp://#{@host.username}@#{@host.hostname}:#{@host.port}#{@localFile.remoteFile.path}"
+        directory = if relativePath? then relativePath else "ftp://#{@host.username}@#{@host.hostname}:#{@host.port}#{@localFile.remoteFile.path}"
       else
         directory = atom.project.relativize(path.dirname(sessionPath))
         directory = if directory.length > 0 then directory else path.basename(path.dirname(sessionPath))


### PR DESCRIPTION
I had issue #77 so I went ahead and implemented the feature.
If the file is in your default directory, the title you get is relative to that directory otherwise default behaviour.

![atom-remote-edit-pull-req-blured](https://cloud.githubusercontent.com/assets/9994172/8101659/9d352834-105c-11e5-8c42-45cba6abe66c.png)
