### PR TITLE
Save files in tmp with the same path as on the server.

### DIFF
--- a/lib/view/files-view.coffee
+++ b/lib/view/files-view.coffee
@@ -5,6 +5,7 @@ LocalFile = require '../model/local-file'
 Dialog = require './dialog'
 
 fs = require 'fs'
+mkdir = require 'mkdirp'
 os = require 'os'
 async = require 'async'
 util = require 'util'
@@ -137,7 +138,7 @@ module.exports =
     updatePath: (next) =>
       @path = @getNewPath(next)
 
-    getDefaultSaveDirForHost: (callback) ->
+    makeDir: (remotePath, callback) ->
       async.waterfall([
         (callback) ->
           fs.realpath(os.tmpDir(), callback)
@@ -151,8 +152,8 @@ module.exports =
             )
           )
         (tmpDir, callback) =>
-          tmpDir = tmpDir + path.sep + @host.hashCode()
-          fs.mkdir(tmpDir, ((err) ->
+          tmpDir = tmpDir + remotePath
+          mkdir(tmpDir, ((err) ->
             if err? && err.code == 'EEXIST'
               callback(null, tmpDir)
             else
@@ -170,9 +171,9 @@ module.exports =
         @setLoading("Downloading file...")
         async.waterfall([
           (callback) =>
-            @getDefaultSaveDirForHost(callback)
+            @makeDir(file.path.slice(0, -file.name.length), callback)
           (savePath, callback) =>
-            savePath = savePath + path.sep + (new Date()).getTime().toString() + "-" + file.name
+            savePath = savePath + path.sep + file.name
             @host.getFileData(file, ((err, data) -> callback(err, data, savePath)))
           (data, savePath, callback) ->
             fs.writeFile(savePath, data, (err) -> callback(err, savePath))

--- a/lib/view/files-view.coffee
+++ b/lib/view/files-view.coffee
@@ -143,7 +143,7 @@ module.exports =
         (callback) ->
           fs.realpath(os.tmpDir(), callback)
         (tmpDir, callback) ->
-          tmpDir = tmpDir + path.sep + (new Date()).getTime().toString() + "-" + "remote-edit" 
+          tmpDir = tmpDir + path.sep + "remote-edit" + "-" + (new Date()).getTime().toString()
           fs.mkdir(tmpDir, ((err) ->
             if err? && err.code == 'EEXIST'
               callback(null, tmpDir)
@@ -152,7 +152,7 @@ module.exports =
             )
           )
         (tmpDir, callback) =>
-          tmpDir = tmpDir + remotePath
+          tmpDir = tmpDir + path.sep + remotePath
           mkdir(tmpDir, ((err) ->
             if err? && err.code == 'EEXIST'
               callback(null, tmpDir)
@@ -171,7 +171,7 @@ module.exports =
         @setLoading("Downloading file...")
         async.waterfall([
           (callback) =>
-            @makeDir(file.path.slice(0, -file.name.length), callback)
+            @makeDir(@host.username + "-" + @host.hostname + path.sep + file.path.slice(0, -file.name.length), callback)
           (savePath, callback) =>
             savePath = savePath + path.sep + file.name
             @host.getFileData(file, ((err, data) -> callback(err, data, savePath)))

--- a/lib/view/files-view.coffee
+++ b/lib/view/files-view.coffee
@@ -143,7 +143,7 @@ module.exports =
         (callback) ->
           fs.realpath(os.tmpDir(), callback)
         (tmpDir, callback) ->
-          tmpDir = tmpDir + path.sep + "remote-edit"
+          tmpDir = tmpDir + path.sep + (new Date()).getTime().toString() + "-" + "remote-edit" 
           fs.mkdir(tmpDir, ((err) ->
             if err? && err.code == 'EEXIST'
               callback(null, tmpDir)

--- a/package.json
+++ b/package.json
@@ -20,18 +20,19 @@
     "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
-    "ftp": ">=0.3.7",
     "async": ">=0.9.0",
+    "atom-space-pen-views": "^2.0.3",
     "file-size": ">=0.0.5",
-    "moment": ">=2.7.0",
-    "ssh2": "~0.4.7",
-    "serializable": ">=1.0.0",
-    "string-hash": ">=1.1.0",
-    "osenv": ">=0.1.0",
-    "underscore-plus": ">=1.5.0",
     "fs-plus": ">=2.2.3",
+    "ftp": ">=0.3.7",
+    "mkdirp": ">=0.5.1",
+    "moment": ">=2.7.0",
+    "osenv": ">=0.1.0",
     "q": ">=1.0.1",
-    "atom-space-pen-views": "^2.0.3"
+    "serializable": ">=1.0.0",
+    "ssh2": "~0.4.7",
+    "string-hash": ">=1.1.0",
+    "underscore-plus": ">=1.5.0"
   },
   "devDependencies": {
     "temp": "*"


### PR DESCRIPTION
I don't know if you'd want to change this behaviour or not but I really like this from Sublime's SFTP plugin.
This makes it much easier to find where this file is coming from when you have a lot of files open (hover over the tab title or look at the footer).