### PR TITLE
quickfix for TextEditor constructor going private

### DIFF
--- a/lib/model/inter-process-data.coffee
+++ b/lib/model/inter-process-data.coffee
@@ -8,7 +8,6 @@ SftpHost = null
 LocalFile = null
 RemoteFile = null
 _ = null
-RemoteEditEditor = null
 
 module.exports =
   class InterProcessData
@@ -35,10 +34,9 @@ module.exports =
         @addSubscriptionToHost(host)
 
       if atom.config.get 'remote-edit.notifications'
-        RemoteEditEditor ?= require '../model/remote-edit-editor'
 
         @disposables.add atom.workspace.observeTextEditors((editor) =>
-          if editor instanceof RemoteEditEditor
+          if editor.remoteEdit
             # If a host emits information ('info'), forward this to @messages
             @disposables.add editor.host.onInfo (info) => atom.notifications.add(info.type, info.message)
         )

--- a/lib/model/remote-edit-editor.coffee
+++ b/lib/model/remote-edit-editor.coffee
@@ -17,139 +17,147 @@ async = null
 Dialog = null
 _ = null
 
-module.exports =
+makeRemoteEditor = (e) ->
+  e.remoteEdit = true
+  e.getIconName = () =>
+    "globe"
+
+  e.getTitle = () ->
+    if @localFile?
+      @localFile.name
+    else if sessionPath = @getPath()
+      path.basename(sessionPath)
+    else
+      "undefined"
+
+  e.getLongTitle = () ->
+    Host ?= require './host'
+    FtpHost ?= require './ftp-host'
+    SftpHost ?= require './sftp-host'
+
+    if i = @localFile.remoteFile.path.indexOf(@host.directory) > -1
+      relativePath = @localFile.remoteFile.path[(i+@host.directory.length)..]
+
+    fileName = @getTitle()
+    if @host instanceof SftpHost and @host? and @localFile?
+      directory = if relativePath? then relativePath else "sftp://#{@host.username}@#{@host.hostname}:#{@host.port}#{@localFile.remoteFile.path}"
+    else if @host instanceof FtpHost and @host? and @localFile?
+      directory = if relativePath? then relativePath else "ftp://#{@host.username}@#{@host.hostname}:#{@host.port}#{@localFile.remoteFile.path}"
+    else
+      directory = atom.project.relativize(path.dirname(sessionPath))
+      directory = if directory.length > 0 then directory else path.basename(path.dirname(sessionPath))
+
+    "#{fileName} - #{directory}"
+
+  e.onDidSaved = (callback) ->
+    @emitter.on 'did-saved', callback
+
+  e.save = () ->
+    @buffer.save()
+    @emitter.emit 'saved'
+    @initiateUpload()
+
+  e.saveAs = (filePath) ->
+    @buffer.saveAs(filePath)
+    @localFile.path = filePath
+    @emitter.emit 'saved'
+    @initiateUpload()
+
+  e.initiateUpload = () ->
+    if atom.config.get 'remote-edit.uploadOnSave'
+      @upload()
+    else
+      Dialog ?= require '../view/dialog'
+      chosen = atom.confirm
+        message: "File has been saved. Do you want to upload changes to remote host?"
+        detailedMessage: "The changes exists on disk and can be uploaded later."
+        buttons: ["Upload", "Cancel"]
+      switch chosen
+        when 0 then @upload()
+        when 1 then return
+
+  e.upload = (connectionOptions = {}) ->
+    async ?= require 'async'
+    _ ?= require 'underscore-plus'
+    if @localFile? and @host?
+      async.waterfall([
+        (callback) =>
+          if @host.usePassword and !connectionOptions.password?
+            if @host.password == "" or @host.password == '' or !@host.password?
+              async.waterfall([
+                (callback) ->
+                  Dialog ?= require '../view/dialog'
+                  passwordDialog = new Dialog({prompt: "Enter password"})
+                  passwordDialog.toggle(callback)
+              ], (err, result) =>
+                connectionOptions = _.extend({password: result}, connectionOptions)
+                callback(null)
+              )
+            else
+              callback(null)
+          else
+            callback(null)
+        (callback) =>
+          if !@host.isConnected()
+            @host.connect(callback, connectionOptions)
+          else
+            callback(null)
+        (callback) =>
+          @host.writeFile(@localFile, callback)
+      ], (err) =>
+        if err? and @host.usePassword
+          async.waterfall([
+            (callback) ->
+              Dialog ?= require '../view/dialog'
+              passwordDialog = new Dialog({prompt: "Enter password"})
+              passwordDialog.toggle(callback)
+          ], (err, result) =>
+            @upload({password: result})
+          )
+      )
+    else
+      console.error 'LocalFile and host not defined. Cannot upload file!'
+
+  return e
+
+module.exports.makeRemoteEditor = makeRemoteEditor
+"""
   class RemoteEditEditor extends TextEditor
     atom.deserializers.add(this)
 
     constructor: ({@softTabs, initialLine, initialColumn, tabLength, softWrap, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini, @host, @localFile}) ->
       super({@softTabs, initialLine, initialColumn, tabLength, softWrap, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini})
 
-    getIconName: ->
-      "globe"
 
-    getTitle: ->
-      if @localFile?
-        @localFile.name
-      else if sessionPath = @getPath()
-        path.basename(sessionPath)
+  serialize: ->
+    deserializer: 'RemoteEditEditor'
+    id: @id
+    softTabs: @softTabs
+    scrollTop: @scrollTop
+    scrollLeft: @scrollLeft
+    displayBuffer: @displayBuffer.serialize()
+    title: @title
+    localFile: @localFile?.serialize()
+    host: @host?.serialize()
+
+  @deserialize: (state) ->
+    try
+      displayBuffer = DisplayBuffer.deserialize(state.displayBuffer)
+    catch error
+      if error.syscall is 'read'
+        return # error reading the file, dont deserialize an editor for it
       else
-        "undefined"
+        throw error
+    state.displayBuffer = displayBuffer
+    state.registerEditor = true
+    if state.localFile?
+      LocalFile = require '../model/local-file'
+      state.localFile = LocalFile.deserialize(state.localFile)
+    if state.host?
+      Host = require '../model/host'
+      FtpHost = require '../model/ftp-host'
+      SftpHost = require '../model/sftp-host'
+      state.host = Host.deserialize(state.host)
+    new this(state)
 
-    getLongTitle: ->
-      Host ?= require './host'
-      FtpHost ?= require './ftp-host'
-      SftpHost ?= require './sftp-host'
-
-      if i = @localFile.remoteFile.path.indexOf(@host.directory) > -1
-        relativePath = @localFile.remoteFile.path[(i+@host.directory.length)..]
-
-      fileName = @getTitle()
-      if @host instanceof SftpHost and @host? and @localFile?
-        directory = if relativePath? then relativePath else "sftp://#{@host.username}@#{@host.hostname}:#{@host.port}#{@localFile.remoteFile.path}"
-      else if @host instanceof FtpHost and @host? and @localFile?
-        directory = if relativePath? then relativePath else "ftp://#{@host.username}@#{@host.hostname}:#{@host.port}#{@localFile.remoteFile.path}"
-      else
-        directory = atom.project.relativize(path.dirname(sessionPath))
-        directory = if directory.length > 0 then directory else path.basename(path.dirname(sessionPath))
-
-      "#{fileName} - #{directory}"
-
-    onDidSaved: (callback) ->
-      @emitter.on 'did-saved', callback
-
-    save: ->
-      @buffer.save()
-      @emitter.emit 'saved'
-      @initiateUpload()
-
-    saveAs: (filePath) ->
-      @buffer.saveAs(filePath)
-      @localFile.path = filePath
-      @emitter.emit 'saved'
-      @initiateUpload()
-
-    initiateUpload: ->
-      if atom.config.get 'remote-edit.uploadOnSave'
-        @upload()
-      else
-        Dialog ?= require '../view/dialog'
-        chosen = atom.confirm
-          message: "File has been saved. Do you want to upload changes to remote host?"
-          detailedMessage: "The changes exists on disk and can be uploaded later."
-          buttons: ["Upload", "Cancel"]
-        switch chosen
-          when 0 then @upload()
-          when 1 then return
-
-    upload: (connectionOptions = {}) ->
-      async ?= require 'async'
-      _ ?= require 'underscore-plus'
-      if @localFile? and @host?
-        async.waterfall([
-          (callback) =>
-            if @host.usePassword and !connectionOptions.password?
-              if @host.password == "" or @host.password == '' or !@host.password?
-                async.waterfall([
-                  (callback) ->
-                    Dialog ?= require '../view/dialog'
-                    passwordDialog = new Dialog({prompt: "Enter password"})
-                    passwordDialog.toggle(callback)
-                ], (err, result) =>
-                  connectionOptions = _.extend({password: result}, connectionOptions)
-                  callback(null)
-                )
-              else
-                callback(null)
-            else
-              callback(null)
-          (callback) =>
-            if !@host.isConnected()
-              @host.connect(callback, connectionOptions)
-            else
-              callback(null)
-          (callback) =>
-            @host.writeFile(@localFile, callback)
-        ], (err) =>
-          if err? and @host.usePassword
-            async.waterfall([
-              (callback) ->
-                Dialog ?= require '../view/dialog'
-                passwordDialog = new Dialog({prompt: "Enter password"})
-                passwordDialog.toggle(callback)
-            ], (err, result) =>
-              @upload({password: result})
-            )
-        )
-      else
-        console.error 'LocalFile and host not defined. Cannot upload file!'
-
-    serialize: ->
-      deserializer: 'RemoteEditEditor'
-      id: @id
-      softTabs: @softTabs
-      scrollTop: @scrollTop
-      scrollLeft: @scrollLeft
-      displayBuffer: @displayBuffer.serialize()
-      title: @title
-      localFile: @localFile?.serialize()
-      host: @host?.serialize()
-
-    @deserialize: (state) ->
-      try
-        displayBuffer = DisplayBuffer.deserialize(state.displayBuffer)
-      catch error
-        if error.syscall is 'read'
-          return # error reading the file, dont deserialize an editor for it
-        else
-          throw error
-      state.displayBuffer = displayBuffer
-      state.registerEditor = true
-      if state.localFile?
-        LocalFile = require '../model/local-file'
-        state.localFile = LocalFile.deserialize(state.localFile)
-      if state.host?
-        Host = require '../model/host'
-        FtpHost = require '../model/ftp-host'
-        SftpHost = require '../model/sftp-host'
-        state.host = Host.deserialize(state.host)
-      new this(state)
+"""


### PR DESCRIPTION
issue of serializing and deserializing is not solved! Mostly because I have no insight how and where that helps. Opening and saving in Atom 1.2.0 works now with this fix (should also work in lower versions) - maybe take it as a starting point for creating a full workaround for the fact TextEditor class constructor should no longer be called directly. Serializing, or actually deserializing, without a derived class - no clue how that should work, this is why I didn't implement any of the two. Maybe chime in with issue https://github.com/atom/atom/issues/9237 to get a hack-less implementation going ;)