### PR TITLE
cleaner implementation of RemoteEditEditor

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,3 +1,4 @@
+_ = require 'underscore-plus'
 # Import needed to register deserializer
 RemoteEditEditor = require './model/remote-edit-editor'
 
@@ -138,4 +139,11 @@ module.exports =
         host = Host.deserialize(JSON.parse(decodeURIComponent(query.host)))
 
         atom.project.bufferForPath(localFile.path).then (buffer) ->
-          editor = new RemoteEditEditor({buffer: buffer, registerEditor: true, host: host, localFile: localFile})
+          params = {buffer: buffer, registerEditor: true, host: host, localFile: localFile}
+          # copied from workspace.buildTextEditor
+          ws = atom.workspace
+          params = _.extend({
+            config: ws.config, notificationManager: ws.notificationManager, packageManager: ws.packageManager, clipboard: ws.clipboard, viewRegistry: ws.viewRegistry,
+            grammarRegistry: ws.grammarRegistry, project: ws.project, assert: ws.assert, applicationDelegate: ws.applicationDelegate
+          }, params)
+          editor = new RemoteEditEditor(params)

--- a/lib/model/remote-edit-editor.coffee
+++ b/lib/model/remote-edit-editor.coffee
@@ -21,8 +21,13 @@ module.exports =
   class RemoteEditEditor extends TextEditor
     atom.deserializers.add(this)
 
-    constructor: ({@softTabs, initialLine, initialColumn, tabLength, softWrap, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini, @host, @localFile}) ->
-      super({@softTabs, initialLine, initialColumn, tabLength, softWrap, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini})
+    constructor: (params = {}) ->
+      console.log(params)
+      super(params)
+      if params.host
+        @host = params.host
+      if params.localFile
+        @localFile = params.localFile
 
     getIconName: ->
       "globe"
@@ -124,15 +129,11 @@ module.exports =
         console.error 'LocalFile and host not defined. Cannot upload file!'
 
     serialize: ->
-      deserializer: 'RemoteEditEditor'
-      id: @id
-      softTabs: @softTabs
-      scrollTop: @scrollTop
-      scrollLeft: @scrollLeft
-      displayBuffer: @displayBuffer.serialize()
-      title: @title
-      localFile: @localFile?.serialize()
-      host: @host?.serialize()
+      data = super
+      data.deserializer = 'RemoteEditEditor'
+      data.localFile = @localFile?.serialize()
+      data.host = @host?.serialize()
+      return data
 
     @deserialize: (state) ->
       try

--- a/lib/model/remote-edit-editor.coffee
+++ b/lib/model/remote-edit-editor.coffee
@@ -22,7 +22,6 @@ module.exports =
     atom.deserializers.add(this)
 
     constructor: (params = {}) ->
-      console.log(params)
       super(params)
       if params.host
         @host = params.host
@@ -135,14 +134,16 @@ module.exports =
       data.host = @host?.serialize()
       return data
 
-    @deserialize: (state) ->
+    # mostly copied from TextEditor.deserialize
+    @deserialize: (state, atomEnvironment) ->
       try
-        displayBuffer = DisplayBuffer.deserialize(state.displayBuffer)
+        displayBuffer = DisplayBuffer.deserialize(state.displayBuffer, atomEnvironment)
       catch error
         if error.syscall is 'read'
           return # error reading the file, dont deserialize an editor for it
         else
           throw error
+
       state.displayBuffer = displayBuffer
       state.registerEditor = true
       if state.localFile?
@@ -153,4 +154,16 @@ module.exports =
         FtpHost = require '../model/ftp-host'
         SftpHost = require '../model/sftp-host'
         state.host = Host.deserialize(state.host)
+      # displayBuffer has no getMarkerLayer
+      #state.selectionsMarkerLayer = displayBuffer.getMarkerLayer(state.selectionsMarkerLayerId)
+      state.config = atomEnvironment.config
+      state.notificationManager = atomEnvironment.notifications
+      state.packageManager = atomEnvironment.packages
+      state.clipboard = atomEnvironment.clipboard
+      state.viewRegistry = atomEnvironment.views
+      state.grammarRegistry = atomEnvironment.grammars
+      state.project = atomEnvironment.project
+      state.assert = atomEnvironment.assert.bind(atomEnvironment)
+      state.applicationDelegate = atomEnvironment.applicationDelegate
       new this(state)
+

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "email": "sverre.aleksandersen@gmail.com"
   },
   "engines": {
-    "atom": ">=1.1.0 <2.0.0"
+    "atom": ">=1.2.3 <2.0.0"
   },
   "dependencies": {
     "ftp": ">=0.3.7",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "q": ">=1.0.1",
     "atom-space-pen-views": "^2.0.3",
     "mkdirp": "~0.5.1",
-    "upath": "~0.1.6"
+    "upath": "~0.1.6",
+    "temp": ">=0.8.3"
   },
   "optionalDependencies": {
     "keytar": "~3.0.0"


### PR DESCRIPTION
serializer possibly works too, broken in Atom see https://github.com/atom/atom/pull/9664

sorry for my first pull request with the crazy workaround for atom 1.2.x this one is cleaner and should work fine