### PR TITLE
Remove reference to removed display-buffer

### DIFF
--- a/lib/model/remote-edit-editor.coffee
+++ b/lib/model/remote-edit-editor.coffee
@@ -6,7 +6,6 @@ catch e
   # Catch error
 TextEditor = Editor ? require path.resolve resourcePath, 'src', 'text-editor'
 
-DisplayBuffer = require path.resolve resourcePath, 'src', 'display-buffer'
 
 # Defer requiring
 Host = null
@@ -137,7 +136,7 @@ module.exports =
     # mostly copied from TextEditor.deserialize
     @deserialize: (state, atomEnvironment) ->
       try
-        displayBuffer = DisplayBuffer.deserialize(state.displayBuffer, atomEnvironment)
+        displayBuffer = TextEditor.deserialize(state.displayBuffer, atomEnvironment)
       catch error
         if error.syscall is 'read'
           return # error reading the file, dont deserialize an editor for it


### PR DESCRIPTION
Atom 1.9.0 removed display-buffer.  Use the deserializer in TextEditor instead.
