### PR TITLE
DisplayBuffer deprecated in Atom 1.9

### DIFF
--- a/lib/model/remote-edit-editor.coffee
+++ b/lib/model/remote-edit-editor.coffee
@@ -6,7 +6,7 @@ catch e
   # Catch error
 TextEditor = Editor ? require path.resolve resourcePath, 'src', 'text-editor'
 
-DisplayBuffer = require path.resolve resourcePath, 'src', 'display-buffer'
+DisplayBuffer = TextEditor.prototype.displayBuffer
 
 # Defer requiring
 Host = null


### PR DESCRIPTION
[Issue #189](https://github.com/sveale/remote-edit/issues/189) Not sure why this hasn't been fixed