### PR TITLE
fix the resourcePath

### DIFF
--- a/lib/model/remote-edit-editor.coffee
+++ b/lib/model/remote-edit-editor.coffee
@@ -1,5 +1,5 @@
 path = require 'path'
-resourcePath = atom.config.resourcePath
+resourcePath = atom.getLoadSettings().resourcePath
 try
   Editor = require path.resolve resourcePath, 'src', 'editor'
 catch e


### PR DESCRIPTION
after getting the following error:
`Path must be a string. Received undefined`
i am following a method by @eth0izzle to fix this bug that reported on issue 243